### PR TITLE
Modified network security configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
+
 # Papilio by Chrysalis
+
+## Setting up the BACKEND_API_URL environment variable
+### To be able to make API requests over the network in a debug environment we must configure a couple of things:
+
+Add the following line to the local.properties file:
+
+        BACKEND_API_URL=http://localhost:1337/api/user/
+
+After starting the local  android emulator type this command in the terminal:
+
+	    adb reverse tcp:1337 tcp:1337
+
+This will forward all requests made on port 1337 of the emulator to port 1337 of the local PC running the backend
 
 ## Test Code Coverage for integrated tests
 

--- a/app/src/main/java/com/soen490chrysalis/papilio/services/network/UserApi.kt
+++ b/app/src/main/java/com/soen490chrysalis/papilio/services/network/UserApi.kt
@@ -1,6 +1,5 @@
 package com.soen490chrysalis.papilio.services.network
 
-import androidx.annotation.Nullable
 import com.soen490chrysalis.papilio.BuildConfig
 import com.soen490chrysalis.papilio.services.network.requests.UserRequest
 import com.soen490chrysalis.papilio.services.network.responses.GetUserByFirebaseIdResponse

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">184.160.92.157</domain>
-        <domain includeSubdomains="true">192.168.1.36</domain>
+        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
# General info

**Issue number**: No issue

**Task description**: 

 - Modified network security configuration to only have localhost instead of a list of IP addresses
 - Modified readme to explain the steps to enable port forwarding on the emulator

# Testing
To test this feature you have to:

1. Run the backend server
2. Follow the readme steps to enable port forwarding from emulator to local computer
3. Clear the application (together with the cache)
4. Run the application and try to login & verify that network requests are made to the backend
5. Stop the app but don't delete it
6. Start the app again from the android app menu and verify that you are redirected to the main activity page without needing to login or do anything
